### PR TITLE
Task specfic key encryption

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -4,7 +4,7 @@ build = 'build.rs'
 edition = '2018'
 license = 'GPL-3.0'
 name = 'advanca-node'
-version = '0.1.0'
+version = '0.2.0'
 
 [[bin]]
 name = 'advanca-node'

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -31,9 +31,9 @@ use std::time::Duration;
 
 // Our native executor instance.
 native_executor_instance!(
-	pub Executor,
-	advanca_runtime::api::dispatch,
-	advanca_runtime::native_version,
+    pub Executor,
+    advanca_runtime::api::dispatch,
+    advanca_runtime::native_version,
 );
 
 construct_simple_protocol! {

--- a/pallets/advanca-core/Cargo.toml
+++ b/pallets/advanca-core/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Advanca Authors']
 edition = '2018'
 license = 'GPL-3.0'
 name = 'advanca-core'
-version = '0.1.0'
+version = '0.2.0'
 
 [dev-dependencies.sp-core]
 default-features = false

--- a/pallets/advanca-core/src/lib.rs
+++ b/pallets/advanca-core/src/lib.rs
@@ -136,10 +136,8 @@ pub struct Task<TaskId, AccountId, Duration, TaskSpec, TaskStatus, Ciphertext> {
     pub task_spec: TaskSpec,
     /// The worker who accepted the task. It may be none at the beginning.
     pub worker: Option<AccountId>,
-    /// The worker's ephemeral key for the particular task
-    pub worker_ephemeral_pubkey: Option<Vec<u8>>,
-    /// The signature for the worker's ephemeral pubkey using the worker's registered private key
-    pub worker_ephemeral_signature: Option<Vec<u8>>,
+    /// The worker's ephemeral key for the particular task signed using its registered key
+    pub worker_signed_ephemeral_pubkey: Option<Vec<u8>>,
     /// The worker's service url saved in ciphertext encrypted by owner's public key
     pub worker_url: Option<Ciphertext>,
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Advanca Authors']
 edition = '2018'
 license = 'GPL-3.0'
 name = 'advanca-runtime'
-version = '0.1.0'
+version = '0.2.0'
 
 [dependencies.aura]
 default-features = false

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -255,22 +255,22 @@ impl advanca_core::Trait for Runtime {
 }
 
 construct_runtime!(
-	pub enum Runtime where
-		Block = Block,
-		NodeBlock = opaque::Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
-	{
-		System: system::{Module, Call, Storage, Config, Event},
-		Timestamp: timestamp::{Module, Call, Storage, Inherent},
-		Aura: aura::{Module, Config<T>, Inherent(Timestamp)},
-		Grandpa: grandpa::{Module, Call, Storage, Config, Event},
-		Indices: indices,
-		Balances: balances,
-		TransactionPayment: transaction_payment::{Module, Storage},
-		Sudo: sudo,
+    pub enum Runtime where
+        Block = Block,
+        NodeBlock = opaque::Block,
+        UncheckedExtrinsic = UncheckedExtrinsic
+    {
+        System: system::{Module, Call, Storage, Config, Event},
+        Timestamp: timestamp::{Module, Call, Storage, Inherent},
+        Aura: aura::{Module, Config<T>, Inherent(Timestamp)},
+        Grandpa: grandpa::{Module, Call, Storage, Config, Event},
+        Indices: indices,
+        Balances: balances,
+        TransactionPayment: transaction_payment::{Module, Storage},
+        Sudo: sudo,
         AdvancaCore: advanca_core::{Module, Call, Storage, Event<T>},
-		RandomnessCollectiveFlip: randomness_collective_flip::{Module, Call, Storage},
-	}
+        RandomnessCollectiveFlip: randomness_collective_flip::{Module, Call, Storage},
+    }
 );
 
 /// The address format for describing accounts.


### PR DESCRIPTION
This pull request adds support for advanca-node to enable per task ephemeral keys.

* Addition of signed_owner_task_pubkey to Task struct
* Addition of worker_signed_ephemeral_pubkey to Task struct